### PR TITLE
Add Spectrum fields in CIF1 data model

### DIFF
--- a/include/vrtgen/packing/cif1.hpp
+++ b/include/vrtgen/packing/cif1.hpp
@@ -487,6 +487,189 @@ public:
 }; // end class SNRNoise
 
 /**
+ * @class Spectrum
+ * @brief Spectrum field (VITA 49.2-2017 Section 9.6.1)
+ */
+class Spectrum
+{
+public:
+    uint32_t spectrum_type() const noexcept
+    {
+        return m_spectrum_type;
+    }
+    void spectrum_type(uint32_t value) noexcept
+    {
+        m_spectrum_type = value;
+    }
+    uint32_t window_type() const noexcept
+    {
+        return m_window_type;
+    }
+    void window_type(uint32_t value) noexcept
+    {
+        m_window_type = value;
+    }
+    uint32_t num_transform_points() const noexcept
+    {
+        return m_num_transform_points;
+    }
+    void num_transform_points(uint32_t value) noexcept
+    {
+        m_num_transform_points = value;
+    }
+    uint32_t num_window_points() const noexcept
+    {
+        return m_num_window_points;
+    }
+    void num_window_points(uint32_t value) noexcept
+    {
+        m_num_window_points = value;
+    }
+    uint32_t num_averages() const noexcept
+    {
+        return m_num_averages;
+    }
+    void num_averages(uint32_t value) noexcept
+    {
+        m_num_averages = value;
+    }
+    double resolution() const noexcept
+    {
+        return vrtgen::fixed::to_fp<64,20>(vrtgen::swap::from_be(m_resolution));
+    }
+    void resolution(double value) noexcept
+    {
+        m_resolution = vrtgen::swap::to_be(vrtgen::fixed::to_int<64,20>(value));
+    }
+    double span() const noexcept
+    {
+        return vrtgen::fixed::to_fp<64,20>(vrtgen::swap::from_be(m_span));
+    }
+    void span(double value) noexcept
+    {
+        m_span = vrtgen::swap::to_be(vrtgen::fixed::to_int<64,20>(value));
+    }
+    uint32_t weighting_factor() const noexcept
+    {
+        return m_weighting_factor;
+    }
+    void weighting_factor(uint32_t value) noexcept
+    {
+        m_weighting_factor = value;
+    }
+    uint32_t f1_index() const noexcept
+    {
+        return m_f1_index;
+    }
+    void f1_index(uint32_t value) noexcept
+    {
+        m_f1_index = value;
+    }
+    uint32_t f2_index() const noexcept
+    {
+        return m_f2_index;
+    }
+    void f2_index(uint32_t value) noexcept
+    {
+        m_f2_index = value;
+    }
+    uint32_t window_time_delta() const noexcept
+    {
+        return m_window_time_delta;
+    }
+    void window_time_delta(uint32_t value) noexcept
+    {
+        m_window_time_delta = value;
+    }
+    std::size_t size() const
+    {
+        return sizeof(Spectrum);
+    }
+    void pack_into(uint8_t* buffer_ptr) const
+    {
+        std::memcpy(buffer_ptr, &m_spectrum_type, sizeof(m_spectrum_type));
+        buffer_ptr += sizeof(m_spectrum_type);
+
+        std::memcpy(buffer_ptr, &m_window_type, sizeof(m_window_type));
+        buffer_ptr += sizeof(m_window_type);
+
+        std::memcpy(buffer_ptr, &m_num_transform_points, sizeof(m_num_transform_points));
+        buffer_ptr += sizeof(m_num_transform_points);
+
+        std::memcpy(buffer_ptr, &m_num_window_points, sizeof(m_num_window_points));
+        buffer_ptr += sizeof(m_num_window_points);
+
+        std::memcpy(buffer_ptr, &m_resolution, sizeof(m_resolution));
+        buffer_ptr += sizeof(m_resolution);
+
+        std::memcpy(buffer_ptr, &m_span, sizeof(m_span));
+        buffer_ptr += sizeof(m_span);
+
+        std::memcpy(buffer_ptr, &m_num_averages, sizeof(m_num_averages));
+        buffer_ptr += sizeof(m_num_averages);
+
+        std::memcpy(buffer_ptr, &m_weighting_factor, sizeof(m_weighting_factor));
+        buffer_ptr += sizeof(m_weighting_factor);
+
+        std::memcpy(buffer_ptr, &m_f1_index, sizeof(m_f1_index));
+        buffer_ptr += sizeof(m_f1_index);
+
+        std::memcpy(buffer_ptr, &m_f2_index, sizeof(m_f2_index));
+        buffer_ptr += sizeof(m_f2_index);
+
+        std::memcpy(buffer_ptr, &m_window_time_delta, sizeof(m_window_time_delta));
+        buffer_ptr += sizeof(m_window_time_delta);
+    }
+    void unpack_from(const uint8_t* buffer_ptr)
+    {
+        std::memcpy(&m_spectrum_type, buffer_ptr, sizeof(m_spectrum_type));
+        buffer_ptr += sizeof(m_spectrum_type);
+
+        std::memcpy(&m_window_type, buffer_ptr, sizeof(m_window_type));
+        buffer_ptr += sizeof(m_window_type);
+
+        std::memcpy(&m_num_transform_points, buffer_ptr, sizeof(m_num_transform_points));
+        buffer_ptr += sizeof(m_num_transform_points);
+
+        std::memcpy(&m_num_window_points, buffer_ptr, sizeof(m_num_window_points));
+        buffer_ptr += sizeof(m_num_window_points);
+
+        std::memcpy(&m_resolution, buffer_ptr, sizeof(m_resolution));
+        buffer_ptr += sizeof(m_resolution);
+
+        std::memcpy(&m_span, buffer_ptr, sizeof(m_span));
+        buffer_ptr += sizeof(m_span);
+
+        std::memcpy(&m_num_averages, buffer_ptr, sizeof(m_num_averages));
+        buffer_ptr += sizeof(m_num_averages);
+
+        std::memcpy(&m_weighting_factor, buffer_ptr, sizeof(m_weighting_factor));
+        buffer_ptr += sizeof(m_weighting_factor);
+
+        std::memcpy(&m_f1_index, buffer_ptr, sizeof(m_f1_index));
+        buffer_ptr += sizeof(m_f1_index);
+
+        std::memcpy(&m_f2_index, buffer_ptr, sizeof(m_f2_index));
+        buffer_ptr += sizeof(m_f2_index);
+
+        std::memcpy(&m_window_time_delta, buffer_ptr, sizeof(m_window_time_delta));
+        buffer_ptr += sizeof(m_window_time_delta);
+    }
+private:
+    uint32_t m_spectrum_type;
+    uint32_t m_window_type;
+    uint32_t m_num_transform_points;
+    uint32_t m_num_window_points;
+    uint64_t m_resolution;
+    uint64_t m_span;
+    uint32_t m_num_averages;
+    uint32_t m_weighting_factor;
+    uint32_t m_f1_index;
+    uint32_t m_f2_index;
+    uint32_t m_window_time_delta;
+};
+
+/**
  * @class SectorStepScanCIF
  * @brief Sector/Step-Scan Control/Context Indicator Word (VITA 49.2-2017 Section 9.6.2.1)
  */

--- a/src/vrtgen/parser/model/cif1.py
+++ b/src/vrtgen/parser/model/cif1.py
@@ -137,6 +137,59 @@ class Time(FixedPointType):
         self.radix = 22
 
 @dataclass
+class SpectrumType(PackedStruct):
+    """
+    Spectrum Type Subfield [9.6.1.1]
+    """
+    name : str = 'SpectrumType'
+    reserved: IntegerType = field(default_factory=lambda: IntegerType('reserved', bits=12, packed_tag=PackedTag(31,12,0)))
+    spectrum_type: IntegerType = field(default_factory=lambda: IntegerType('spectrum_type', bits=8, packed_tag=PackedTag(19,8,0)))
+    averaging_type: IntegerType = field(default_factory=lambda: IntegerType('averaging_type', bits=8, packed_tag=PackedTag(11,8,0)))
+    window_time : IntegerType = field(default_factory=lambda: IntegerType('window_time', bits=4, packed_tag=PackedTag(3,4,0)))
+
+@dataclass
+class WindowType(PackedStruct):
+    """
+    Window Type Subfield [9.6.1.2]
+    """
+    name : str = 'WindowType'
+    reserved: IntegerType = field(default_factory=lambda: IntegerType('reserved', bits=24, packed_tag=PackedTag(31,24,0)))
+    window_type: IntegerType = field(default_factory=lambda: IntegerType('window_type', bits=8, packed_tag=PackedTag(7,8,0)))
+
+@dataclass
+class SpectrumF1F2Indicies(PackedStruct):
+    """
+    Spectrum F1-F2 Indicies Subfield [9.6.1.9]
+    """
+    name : str = 'SpectrumF1F2Indicies'
+    f1_index : Unsigned32 = field(default_factory=lambda: Unsigned32('f1_index', packed_tag=PackedTag(31,32,0)))
+    f2_index : Unsigned32 = field(default_factory=lambda: Unsigned32('f2_index', packed_tag=PackedTag(31,32,1)))
+
+@dataclass
+class Spectrum(PackedStruct):
+    """
+    Spectrum [9.6.1]
+    """
+    name : str = 'Spectrum'
+    spectrum_type : SpectrumType = field(default_factory=lambda: SpectrumType('spectrum_type', packed_tag=PackedTag(31,32,0)))
+    window_type : WindowType = field(default_factory=lambda: WindowType('window_type', packed_tag=PackedTag(31,32,1)))
+    number_transform_points : Unsigned32 = field(default_factory=lambda: Unsigned32('number_transform_points', packed_tag=PackedTag(31,32,2)))
+    number_window_points : Unsigned32 = field(default_factory=lambda: Unsigned32('number_window_points', packed_tag=PackedTag(31,32,3)))
+    resolution : FixedPoint64r20 = field(default_factory=lambda: FixedPoint64r20('resolution', packed_tag=PackedTag(31,64,4)))
+    span : FixedPoint64r20 = field(default_factory=lambda: FixedPoint64r20('span', packed_tag=PackedTag(31,64,6)))
+    number_averages : Unsigned32 = field(default_factory=lambda: Unsigned32('number_averages', packed_tag=PackedTag(31,32,8)))
+    # The weighting_factor field is defined to be 32-bits, but there is no mention of type.
+    # As it represents a coefficient value, we assume a signed fixed-point w/ radix 16 here.
+    weighting_factor : FixedPointType = field(default_factory=lambda: FixedPointType('weighting_factor', bits=32, signed=True, radix=16, packed_tag=PackedTag(31,32,9)))
+    spectrum_f1_f2_indicies : SpectrumF1F2Indicies = field(default_factory=lambda: SpectrumF1F2Indicies('spectrum_f1_f2_indicies', packed_tag=PackedTag(31, 64, 10)))
+    # There are options for how the window_time_delta field can be defined:
+    # A) Time: 32-bit unsigned int
+    # B) Samples: 32-bit unsigned int
+    # C) Percent Overlap: signed fixed-point w/ radix 12
+    window_time_delta : Unsigned32 = field(default_factory=lambda: Unsigned32('window_time_delta', packed_tag=PackedTag(31,32,12)))
+    # window_time_delta : FixedPointType = field(default_factory=lambda: FixedPointType('window_time_delta', bits=32, signed=True, radix=12, packed_tag=PackedTag(31,32,12)))
+
+@dataclass
 class SectorStepScanCIF(CIF):
     """
     Sector/Step-Scan Control/Context Indicator Word [9.6.2.1]
@@ -383,7 +436,7 @@ class CIF1(CIF):
     aux_gain : CIFEnableType = field(default_factory=lambda: CIFEnableType('aux_gain', type_=Gain(), packed_tag=PackedTag(14,1,0,0)))
     aux_bandwidth : CIFEnableType = field(default_factory=lambda: CIFEnableType('aux_bandwidth', type_=FixedPoint64r20(), packed_tag=PackedTag(13,1,0,0)))
     array_of_cifs : CIFEnableType = field(default_factory=lambda: CIFEnableType('array_of_cifs', packed_tag=PackedTag(11,1,0,0)))
-    spectrum : CIFEnableType = field(default_factory=lambda: CIFEnableType('spectrum', packed_tag=PackedTag(10,1,0,0)))
+    spectrum : CIFEnableType = field(default_factory=lambda: CIFEnableType('spectrum', type_=Spectrum(), packed_tag=PackedTag(10,1,0,0)))
     sector_step_scan : CIFEnableType = field(default_factory=lambda: CIFEnableType('sector_step_scan', type_=SectorStepScan(), packed_tag=PackedTag(9,1,0,0)))
     index_list : CIFEnableType = field(default_factory=lambda: CIFEnableType('index_list', type_=IndexList(), packed_tag=PackedTag(7,1,0,0)))
     discrete_io_32 : CIFEnableType = field(default_factory=lambda: CIFEnableType('discrete_io_32', type_=DiscreteIO32(), packed_tag=PackedTag(6,1,0,0)))


### PR DESCRIPTION
Currently, if you define a simple context packet that uses the spectrum field in CIF1, vrtpktgen throws an in the code generation phase. For example, this YAML:

```yaml
ExampleContext: !Context
  ...
  cif_1: !CIF1
    spectrum: optional
```

...will produce:

```
vrtpktgen cpp ./example-context.yaml
<--- cpp generation stack trace --->
jinja2.exceptions.UndefinedError: 'None' has no attribute 'reserved_bits'
```

The CIF1 data model appears to have a placeholder for the Spectrum field defined in the VITA 49.2 standard in section 9.6.1.

Add the data structures described in section 9.6.1 to avoid this error and use the spectrum field in CIF1.