### PR TITLE
Fix endianess and size bug in spectrum fields

### DIFF
--- a/include/vrtgen/packing/cif1.hpp
+++ b/include/vrtgen/packing/cif1.hpp
@@ -495,43 +495,43 @@ class Spectrum
 public:
     uint32_t spectrum_type() const noexcept
     {
-        return m_spectrum_type;
+        return vrtgen::swap::from_be(m_spectrum_type);
     }
     void spectrum_type(uint32_t value) noexcept
     {
-        m_spectrum_type = value;
+        m_spectrum_type = vrtgen::swap::to_be(value);
     }
     uint32_t window_type() const noexcept
     {
-        return m_window_type;
+        return vrtgen::swap::from_be(m_window_type);
     }
     void window_type(uint32_t value) noexcept
     {
-        m_window_type = value;
+        m_window_type = vrtgen::swap::to_be(value);
     }
     uint32_t num_transform_points() const noexcept
     {
-        return m_num_transform_points;
+        return vrtgen::swap::from_be(m_num_transform_points);
     }
     void num_transform_points(uint32_t value) noexcept
     {
-        m_num_transform_points = value;
+        m_num_transform_points = vrtgen::swap::to_be(value);
     }
     uint32_t num_window_points() const noexcept
     {
-        return m_num_window_points;
+        return vrtgen::swap::from_be(m_num_window_points);
     }
     void num_window_points(uint32_t value) noexcept
     {
-        m_num_window_points = value;
+        m_num_window_points = vrtgen::swap::to_be(value);
     }
     uint32_t num_averages() const noexcept
     {
-        return m_num_averages;
+        return vrtgen::swap::from_be(m_num_averages);
     }
     void num_averages(uint32_t value) noexcept
     {
-        m_num_averages = value;
+        m_num_averages = vrtgen::swap::to_be(value);
     }
     double resolution() const noexcept
     {
@@ -551,39 +551,40 @@ public:
     }
     uint32_t weighting_factor() const noexcept
     {
-        return m_weighting_factor;
+        return vrtgen::swap::from_be(m_weighting_factor);
     }
     void weighting_factor(uint32_t value) noexcept
     {
-        m_weighting_factor = value;
+        m_weighting_factor = vrtgen::swap::to_be(value);
     }
     uint32_t f1_index() const noexcept
     {
-        return m_f1_index;
+        return vrtgen::swap::from_be(m_f1_index);
     }
     void f1_index(uint32_t value) noexcept
     {
-        m_f1_index = value;
+        m_f1_index = vrtgen::swap::to_be(value);
     }
     uint32_t f2_index() const noexcept
     {
-        return m_f2_index;
+        return vrtgen::swap::from_be(m_f2_index);
     }
     void f2_index(uint32_t value) noexcept
     {
-        m_f2_index = value;
+        m_f2_index = vrtgen::swap::to_be(value);
     }
     uint32_t window_time_delta() const noexcept
     {
-        return m_window_time_delta;
+        return vrtgen::swap::from_be(m_window_time_delta);
     }
     void window_time_delta(uint32_t value) noexcept
     {
-        m_window_time_delta = value;
+        m_window_time_delta = vrtgen::swap::to_be(value);
     }
     std::size_t size() const
     {
-        return sizeof(Spectrum);
+        // Spectrum field is always 13 words
+        return sizeof(uint32_t) * 13;
     }
     void pack_into(uint8_t* buffer_ptr) const
     {


### PR DESCRIPTION
Currently, some subfields in the spectrum field are not being swapped correctly which leads to inverted values on the wire. Additionally, compiler padding causes additional padded data to be sent.

To fix these issues, add swapping where necessary and set the size to the static value of 13 words (per the VITA 49.2 spec).

To help validate this code, we've added support for spectral context fields to Wireshark and verified the data shows up properly there: https://gitlab.com/wireshark/wireshark/-/merge_requests/16952.
