### PR TITLE
Fix spectral fields swapping bug

### DIFF
--- a/include/vrtgen/packing/cif1.hpp
+++ b/include/vrtgen/packing/cif1.hpp
@@ -647,22 +647,22 @@ public:
 
     uint32_t num_transform_points() const noexcept
     {
-        return m_num_transform_points;
+        return vrtgen::swap::from_be(m_num_transform_points);
     }
 
     void num_transform_points(uint32_t value) noexcept
     {
-        m_num_transform_points = value;
+        m_num_transform_points = vrtgen::swap::to_be(value);
     }
 
     uint32_t num_window_points() const noexcept
     {
-        return m_num_window_points;
+        return vrtgen::swap::from_be(m_num_window_points);
     }
 
     void num_window_points(uint32_t value) noexcept
     {
-        m_num_window_points = value;
+        m_num_window_points = vrtgen::swap::to_be(value);
     }
 
     double resolution() const noexcept
@@ -687,52 +687,52 @@ public:
 
     uint32_t num_averages() const noexcept
     {
-        return m_num_averages;
+        return vrtgen::swap::from_be(m_num_averages);
     }
 
     void num_averages(uint32_t value) noexcept
     {
-        m_num_averages = value;
+        m_num_averages = vrtgen::swap::to_be(value);
     }
 
     uint32_t weighting_factor() const noexcept
     {
-        return m_weighting_factor;
+        return vrtgen::swap::from_be(m_weighting_factor);
     }
 
     void weighting_factor(uint32_t value) noexcept
     {
-        m_weighting_factor = value;
+        m_weighting_factor = vrtgen::swap::to_be(value);
     }
 
     int32_t f1_index() const noexcept
     {
-        return m_f1_index;
+        return vrtgen::swap::from_be(m_f1_index);
     }
 
     void f1_index(int32_t value) noexcept
     {
-        m_f1_index = value;
+        m_f1_index = vrtgen::swap::to_be(value);
     }
 
     int32_t f2_index() const noexcept
     {
-        return m_f2_index;
+        return vrtgen::swap::from_be(m_f2_index);
     }
 
     void f2_index(int32_t value) noexcept
     {
-        m_f2_index = value;
+        m_f2_index = vrtgen::swap::to_be(value);
     }
 
     uint32_t window_time_delta() const noexcept
     {
-        return m_window_time_delta;
+        return vrtgen::swap::from_be(m_window_time_delta);
     }
 
     void window_time_delta(uint32_t value) noexcept
     {
-        m_window_time_delta = value;
+        m_window_time_delta = vrtgen::swap::to_be(value);
     }
 
     std::size_t size() const

--- a/include/vrtgen/packing/cif1.hpp
+++ b/include/vrtgen/packing/cif1.hpp
@@ -605,14 +605,14 @@ enum class WindowType : uint8_t
 class Spectrum
 {
 public:
-    uint8_t spectrum_type() const noexcept
+    SpectrumType spectrum_type() const noexcept
     {
-        return m_spectrum_type.get<7,8,uint8_t>();
+        return SpectrumType{m_spectrum_type.get<7,8,uint8_t>()};
     }
 
-    void spectrum_type(uint8_t value) noexcept
+    void spectrum_type(SpectrumType value) noexcept
     {
-        m_spectrum_type.set<7,8>(value);
+        m_spectrum_type.set<7,8>(static_cast<uint8_t>(value));
     }
 
     AveragingType averaging_type() const noexcept


### PR DESCRIPTION
Currently, there's an endianness bug in some of the spectral fields
causing incorrect data to be sent on the wire.

For example, let's consider setting the following values in a context
packet:

```c++
context_spectrum.spectrum_type(vrtgen::packing::SpectrumType::LOG_POWER);
context_spectrum.averaging_type(vrtgen::packing::AveragingType::LINEAR);
context_spectrum.window_time(vrtgen::packing::WindowTimeDelta::NONE);
context_spectrum.window_type(vrtgen::packing::WindowType::TRIANGLE);
context_spectrum.num_transform_points(123);
context_spectrum.num_window_points(123);
context_spectrum.resolution(6.25e6);
context_spectrum.span(8.0e6);
context_spectrum.num_averages(123);
context_spectrum.weighting_factor(123);
context_spectrum.f1_index(-123);
context_spectrum.f2_index(123);
context_spectrum.window_time_delta(123);
```

Capturing the packet data using Wireshark, we can see the following values:

```
Spectrum
    Spectrum type: 0x00000101
    Window type: 0x00000001
    Num transform points: 2063597568
    Num window points: 2063597568
    Resolution: 6.250000 MHz
    Span: 8.000000 MHz
    Num averages: 2063597568
    Weighting factor: 2063597568
    F1 index: -2046820353
    F2 index: 2063597568
    Window time-delta: 2063597568
```

Specifically, we see the number of transform points, window points,
averages, weighting factor, F1/F2 indices, and window time-delta do
not match up with what we'd expect.

After adding swapping to the values that don't match up, we get:

```
Spectrum
    Spectrum type: 0x00000101
    Window type: 0x00000001
    Num transform points: 123
    Num window points: 123
    Resolution: 6.250000 MHz
    Span: 8.000000 MHz
    Num averages: 123
    Weighting factor: 123
    F1 index: -123
    F2 index: 123
    Window time-delta: 123
```

While testing this fix, we also noticed the setter for SpectrumType
accepts a raw uint8. Since we have a class that gives semantic meaning
to the value, let's use that instead.

So, instead of:

```c++
context_spectrum.spectrum_type(1);
```

You'd do:

```c++
context_spectrum.spectrum_type(vrtgen::packing::SpectrumType::LOG_POWER);
```